### PR TITLE
Upgrade Cocaine to Terrapin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem "cocaine"
+gem "terrapin"
 
 
 # Added at 2017-12-24 10:16:46 +0100 by coderobe:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     climate_control (0.2.0)
-    cocaine (0.5.8)
-      climate_control (>= 0.0.3, < 1.0)
     coderay (1.1.2)
     colorize (0.8.1)
     method_source (0.9.0)
@@ -11,17 +9,19 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    terrapin (0.6.0)
+      climate_control (>= 0.0.3, < 1.0)
     thor (0.20.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocaine
   colorize (~> 0.8.1)
   posix-spawn (~> 0.3.13)
   pry (~> 0.11.3)
+  terrapin
   thor (~> 0.20.0)
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/src/cli.rb
+++ b/src/cli.rb
@@ -5,7 +5,7 @@ require "colorize"
 require "./src/methods"
 require "./src/utils"
 
-#Cocaine::CommandLine.logger = Logger.new(STDOUT)
+#Terrapin::CommandLine.logger = Logger.new(STDOUT)
 
 module VBiosFinder
   @@wd

--- a/src/extract-7z.rb
+++ b/src/extract-7z.rb
@@ -1,12 +1,12 @@
-require "cocaine"
+require "terrapin"
 
 module VBiosFinder
   class Extract
     def self.p7zip file
       begin
-        line = Cocaine::CommandLine.new("7z", "x :file")
+        line = Terrapin::CommandLine.new("7z", "x :file")
         line.run(file: file)
-      rescue Cocaine::ExitStatusError => e
+      rescue Terrapin::ExitStatusError => e
         puts e.message
         return
       end
@@ -15,10 +15,10 @@ module VBiosFinder
   class Test
     def self.p7zip file
       begin
-        line = Cocaine::CommandLine.new("7z", "l :file | grep 'Type = 7z'")
+        line = Terrapin::CommandLine.new("7z", "l :file | grep 'Type = 7z'")
         line.run(file: file)
         true
-      rescue Cocaine::ExitStatusError => e
+      rescue Terrapin::ExitStatusError => e
         false
       end
     end

--- a/src/extract-innosetup.rb
+++ b/src/extract-innosetup.rb
@@ -1,12 +1,12 @@
-require "cocaine"
+require "terrapin"
 
 module VBiosFinder
   class Extract
     def self.innosetup file
       begin
-        line = Cocaine::CommandLine.new("innoextract", ":file")
+        line = Terrapin::CommandLine.new("innoextract", ":file")
         puts line.run(file: file)
-      rescue Cocaine::ExitStatusError => e
+      rescue Terrapin::ExitStatusError => e
         puts e.message
         return
       end
@@ -15,10 +15,10 @@ module VBiosFinder
   class Test
     def self.innosetup file
       begin
-        line = Cocaine::CommandLine.new("innoextract", "-t :file")
+        line = Terrapin::CommandLine.new("innoextract", "-t :file")
         line.run(file: file)
         true
-      rescue Cocaine::ExitStatusError => e
+      rescue Terrapin::ExitStatusError => e
         false
       end
     end

--- a/src/extract-uefi.rb
+++ b/src/extract-uefi.rb
@@ -1,12 +1,12 @@
-require "cocaine"
+require "terrapin"
 
 module VBiosFinder
   class Extract
     def self.uefi file
       begin
-        line = Cocaine::CommandLine.new("UEFIExtract", ":file all")
+        line = Terrapin::CommandLine.new("UEFIExtract", ":file all")
         line.run(file: file)
-      rescue Cocaine::ExitStatusError => e
+      rescue Terrapin::ExitStatusError => e
         # TODO: fix Test::uefi before uncommenting this
         puts e.message
         return
@@ -16,10 +16,10 @@ module VBiosFinder
   class Test
     def self.uefi file
       begin
-        line = Cocaine::CommandLine.new("UEFIExtract", ":file report")
+        line = Terrapin::CommandLine.new("UEFIExtract", ":file report")
         line.run(file: file)
         true
-      rescue Cocaine::ExitStatusError => e
+      rescue Terrapin::ExitStatusError => e
         false
       end
     end

--- a/src/extract-upx.rb
+++ b/src/extract-upx.rb
@@ -1,12 +1,12 @@
-require "cocaine"
+require "terrapin"
 
 module VBiosFinder
   class Extract
     def self.upx file
       begin
-        line = Cocaine::CommandLine.new("upx", "-d :file -o :outfile")
+        line = Terrapin::CommandLine.new("upx", "-d :file -o :outfile")
         line.run(file: file, outfile: "upx-#{file}")
-      rescue Cocaine::ExitStatusError => e
+      rescue Terrapin::ExitStatusError => e
         puts e.message
         return
       end
@@ -15,10 +15,10 @@ module VBiosFinder
   class Test
     def self.upx file
       begin
-        line = Cocaine::CommandLine.new("upx", "-t :file")
+        line = Terrapin::CommandLine.new("upx", "-t :file")
         line.run(file: file)
         true
-      rescue Cocaine::ExitStatusError => e
+      rescue Terrapin::ExitStatusError => e
         false
       end
     end

--- a/src/methods.rb
+++ b/src/methods.rb
@@ -1,4 +1,4 @@
-require "cocaine"
+require "terrapin"
 require "find"
 require "colorize"
 require "./src/extraction"
@@ -52,13 +52,13 @@ module VBiosFinder
       uefibins = Find.find(".").reject{|e| File.directory? e}.select{|e| e.end_with? ".bin"}
       puts "got #{uefibins.length} modules".colorize(:blue)
       puts "finding vbios".colorize(:blue)
-      line = Cocaine::CommandLine.new("file", "-b :file")
+      line = Terrapin::CommandLine.new("file", "-b :file")
       modules = uefibins.select{|e| line.run(file: e).include? "Video"}
       if modules.length > 0
         puts "#{modules.length} possible candidates".colorize(:green)
         if Utils::installed?("rom-parser", "required for proper rom naming & higher accuracy")
           modules.each do |mod|
-            rom_parser = Cocaine::CommandLine.new("rom-parser", ":file")
+            rom_parser = Terrapin::CommandLine.new("rom-parser", ":file")
             begin
               romdata = rom_parser.run(file: mod)
               romdata = romdata.split("\n")[1].split(", ").map{|e| e.split(": ")}.to_h rescue nil
@@ -67,7 +67,7 @@ module VBiosFinder
                 new_filename = "vbios_#{romdata['vendor']}_#{romdata['device']}.rom"
                 FileUtils.cp(mod, "#{outpath}/#{new_filename}")
               end
-            rescue Cocaine::ExitStatusError => e
+            rescue Terrapin::ExitStatusError => e
               puts "can't determine vbios type of #{File.basename(mod)}, saving as 'vbios_unknown_#{File.basename(mod)}'"
               FileUtils.cp(mod, "#{outpath}/vbios_unknown_#{File.basename(mod)}")
             end

--- a/src/utils.rb
+++ b/src/utils.rb
@@ -1,4 +1,4 @@
-require "cocaine"
+require "terrapin"
 require "mkmf"
 require "find"
 


### PR DESCRIPTION
[Cocaine](https://github.com/thoughtbot/cocaine) is deprecated and has been replaced by [Terrapin](https://github.com/thoughtbot/terrapin).