### PR TITLE
Hp service pack compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Some dependencies might not offer a package for your linux distribution **(like 
 ## Usage
 - Run `bundle install --path=vendor/bundle` to install the required ruby modules **(once)**
 - Run `./vbiosfinder extract /path/to/bios_update.exe` to attempt an extraction
+    - NOTE: /path/to/bios_update.exe **MUST** be a fully qualified path. Do **not** use relative path names
 - A temporary working dir is created at `./tmp-vbiosfinder` which can be removed inbetween runs
 - Extracted VBIOS roms will be placed in `./output`
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Some dependencies might not offer a package for your linux distribution **(like 
 - Run `bundle install --path=vendor/bundle` to install the required ruby modules **(once)**
 - Run `./vbiosfinder extract /path/to/bios_update.exe` to attempt an extraction
     - NOTE: /path/to/bios_update.exe **MUST** be a fully qualified path. Do **not** use relative path names
+    - NOTE: /path/to/bios_update.exe can be an HP Service Pack exe file, e.g. /home/user/sp012345.exe
 - A temporary working dir is created at `./tmp-vbiosfinder` which can be removed inbetween runs
 - Extracted VBIOS roms will be placed in `./output`
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This tool attempts to extract a VBIOS from a bios update  
 Laptops with NVIDIA Optimus graphics often have the dGPU VBIOS integrated in their system BIOS, this makes extracting the VBIOS a complicated process. Provided you have a BIOS Update for your laptop, this tool might be able to automagically extract all available VBIOS from it.
 
+This version adds the ability to extract from HP Service Pack executable files. HP Service Packs contain embedded BIOS and VBIOS for HP laptops. Replacement graphics cards for HP laptops are usually shipped "bare" without any VBIOS installed.
+
 ## Dependencies
 - Ruby
 - bundler **(a ruby gem)**
@@ -31,6 +33,7 @@ Some dependencies might not offer a package for your linux distribution **(like 
 - [ThinkPad T440p](https://github.com/coderobe/VBiosFinder/issues/21)
 - [ThinkPad T530](https://github.com/coderobe/VBiosFinder/issues/34)
 - [TravelMate P645-SG](https://github.com/coderobe/VBiosFinder/issues/9)
+- HP Service Packs
 
 - **note: if your device isn't listed here, feel free to try this tool and report your results!**
 

--- a/src/extract-7z.rb
+++ b/src/extract-7z.rb
@@ -17,10 +17,18 @@ module VBiosFinder
       begin
         line = Terrapin::CommandLine.new("7z", "l :file | grep 'Type = 7z'")
         line.run(file: file)
-        true
+        result_7Z = true
       rescue Terrapin::ExitStatusError => e
-        false
+        result_7Z = false
       end
+      begin
+        line = Terrapin::CommandLine.new("7z", "l :file | grep 'Type = Cab'")
+        line.run(file: file)
+        result_Cab = true
+      rescue Terrapin::ExitStatusError => e
+        result_Cab = false
+      end
+      return result_Cab || result_7z
     end
   end
 end

--- a/src/extract-7z.rb
+++ b/src/extract-7z.rb
@@ -28,7 +28,7 @@ module VBiosFinder
       rescue Terrapin::ExitStatusError => e
         result_Cab = false
       end
-      return result_Cab || result_7z
+      return result_Cab || result_7Z
     end
   end
 end


### PR DESCRIPTION
These changes add the ability to extract from an HP Service Pack executable (e.g. sp012345.exe).
Replacement graphics cards intended for HP laptops will often ship without a VBIOS installed.
The VBIOS files are typically embedded within a larger HP Service Pack. 

Files modified:
README.md
src/extract-7z.rb
